### PR TITLE
Application Activation and Aircraft Binding

### DIFF
--- a/DJISampleDemo/Info.plist
+++ b/DJISampleDemo/Info.plist
@@ -20,6 +20,11 @@
 	<string>1</string>
 	<key>DJISDKAppKey</key>
 	<string>d0254113dcbcb67faf126935</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/DJISampleDemo/ViewController.swift
+++ b/DJISampleDemo/ViewController.swift
@@ -15,51 +15,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var loginButton: UIButton!
     @IBOutlet weak var logoutButton: UIButton!
 
-    private var activationState: DJIAppActivationState! {
-        didSet {
-            switch activationState {
-            case .none:
-                self.activationStateLabel.text = "None"
-            case .some(let state):
-                switch state {
-                case .notSupported:
-                    self.activationStateLabel.text = "App Activation is not supported."
-                case .loginRequired:
-                    self.activationStateLabel.text = "Login is required to activate."
-                case .activated:
-                    self.activationStateLabel.text = "Activated"
-                case .unknown:
-                    self.activationStateLabel.text = "Unknown"
-                }
-            }
-        }
-    }
-
-    private var aircraftBindingState: DJIAppActivationAircraftBindingState! {
-        didSet {
-            switch aircraftBindingState {
-            case .none:
-                self.aircraftBindingStateLabel.text = "None"
-            case .some(let state):
-                switch state {
-                case .initial:
-                    self.aircraftBindingStateLabel.text = "Initial"
-                case .unbound:
-                    self.aircraftBindingStateLabel.text = "Unbound. Use DJI GO to bind the aircraft."
-                case .unboundButCannotSync:
-                    self.aircraftBindingStateLabel.text = "Unbound. Please connect Internet to update state."
-                case .bound:
-                    self.aircraftBindingStateLabel.text = "Bound"
-                case .notRequired:
-                    self.aircraftBindingStateLabel.text = "Binding is not required."
-                case .notSupported:
-                    self.aircraftBindingStateLabel.text = "App Activation is not supported."
-                case .unknown:
-                    self.aircraftBindingStateLabel.text = "Unknown"
-                }
-            }
-        }
-    }
+    private var activationState: DJIAppActivationState!
+    private var aircraftBindingState: DJIAppActivationAircraftBindingState!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -68,6 +25,7 @@ class ViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         DJISDKManager.registerApp(with: self)
+        updeteUI()
     }
 
     @IBAction func onTapLogin(_ sender: UIButton) {
@@ -89,16 +47,58 @@ class ViewController: UIViewController {
             }
         }
     }
+    
+    private func updeteUI() {
+        switch activationState {
+        case .none:
+            self.activationStateLabel.text = "None"
+        case .some(let state):
+            switch state {
+            case .notSupported:
+                self.activationStateLabel.text = "App Activation is not supported."
+            case .loginRequired:
+                self.activationStateLabel.text = "Login is required to activate."
+            case .activated:
+                self.activationStateLabel.text = "Activated"
+            case .unknown:
+                self.activationStateLabel.text = "Unknown"
+            }
+        }
+        
+        switch aircraftBindingState {
+        case .none:
+            self.aircraftBindingStateLabel.text = "None"
+        case .some(let state):
+            switch state {
+            case .initial:
+                self.aircraftBindingStateLabel.text = "Initial"
+            case .unbound:
+                self.aircraftBindingStateLabel.text = "Unbound. Use DJI GO to bind the aircraft."
+            case .unboundButCannotSync:
+                self.aircraftBindingStateLabel.text = "Unbound. Please connect Internet to update state."
+            case .bound:
+                self.aircraftBindingStateLabel.text = "Bound"
+            case .notRequired:
+                self.aircraftBindingStateLabel.text = "Binding is not required."
+            case .notSupported:
+                self.aircraftBindingStateLabel.text = "App Activation is not supported."
+            case .unknown:
+                self.aircraftBindingStateLabel.text = "Unknown"
+            }
+        }
+    }
 }
 
 extension ViewController: DJIAppActivationManagerDelegate {
 
     func manager(_ manager: DJIAppActivationManager!, didUpdate appActivationState: DJIAppActivationState) {
         self.activationState = appActivationState
+        updeteUI()
     }
 
     func manager(_ manager: DJIAppActivationManager!, didUpdate aircraftBindingState: DJIAppActivationAircraftBindingState) {
         self.aircraftBindingState = aircraftBindingState
+        updeteUI()
     }
 }
 


### PR DESCRIPTION
## Overview

- It's needed to release ATS when logging in for my app.
- And, updating the UI method to better than.

## Links

- #2 